### PR TITLE
Fix README example to not run workflow on delete

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,10 @@ Optionally, you may provide credentials to authenticate as a GitHub App and labe
 
 ```yaml
 name: Demo
-on: [issue_comment]
+# Prevent the workflow from running again when deleting a comment with the trigger phrase
+on:
+  issue_comment:
+    types: [created]
 
 jobs:
   label-pr:


### PR DESCRIPTION
Great tool here! Integrated it this morning into my own project and was surprised how easy and effective it is.

One thing that I noticed in my trials: the example in the README will run the workflow for both creation & deletion of a comment containing a trigger phrase. This seems like it would be (more often than not) undesirable for most use cases.

Looking into it more, I saw that the [issue_comment](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#issue_comment) workflow event has `created`, `edited`, and `deleted` types. Proposing this small change to the demo to help the next person become immediately aware that they can explicitly limit the runs to creation only.

Thanks again for such a great tool!

